### PR TITLE
feat: add support for searching storage networks with `/nt [query]`

### DIFF
--- a/src/main/java/de/kwantux/networks/terminals/commands/InterfaceCommand.java
+++ b/src/main/java/de/kwantux/networks/terminals/commands/InterfaceCommand.java
@@ -7,6 +7,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.incendo.cloud.CommandManager;
 import org.incendo.cloud.context.CommandContext;
+import org.incendo.cloud.parser.standard.StringParser;
 import org.incendo.cloud.setting.ManagerSetting;
 import org.jetbrains.annotations.Nullable;
 
@@ -25,6 +26,7 @@ public class InterfaceCommand extends CommandHandler {
 
         cmd.command(cmd.commandBuilder("networksterminals", "networkterminals", "networksterminal", "netterm", "nt")
                 .senderType(Player.class)
+                .optional("filter", StringParser.greedyStringParser())
                 .handler(this::openMenu)
                 .permission("networks.terminals.use")
         );
@@ -43,7 +45,8 @@ public class InterfaceCommand extends CommandHandler {
         Player player = context.sender();
         Network network = selection(player);
         if (network == null) return;
-        InventoryMenuManager.addInventoryMenu(player, selection(player));
+        String filter = context.getOrDefault("filter", null);
+        InventoryMenuManager.addInventoryMenu(player, network, filter);
     }
 
 

--- a/src/main/java/de/kwantux/networks/terminals/inventory/InventoryMenu.java
+++ b/src/main/java/de/kwantux/networks/terminals/inventory/InventoryMenu.java
@@ -4,6 +4,7 @@ import de.kwantux.networks.Network;
 import de.kwantux.networks.terminals.component.TerminalComponent;
 import net.kyori.adventure.bossbar.BossBar;
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
 import net.kyori.adventure.title.Title;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -29,11 +30,13 @@ public class InventoryMenu {
     private int page;
     private BossBar bossBar;
     private final TerminalComponent component;
+    private final String filter;
 
-    public InventoryMenu(Player player, Network network) {
+    public InventoryMenu(Player player, Network network, String filter) {
 
         this.player = player;
         this.network = network;
+        this.filter = filter != null ? filter.toLowerCase() : null;
 
         component = new TerminalComponent(player);
         network.addComponent(component);
@@ -99,8 +102,7 @@ public class InventoryMenu {
         items.sort(Comparator.comparing(ItemStack::getType));
 
         for (ItemStack item : items) {
-
-            if (item != null) {
+            if (item != null && matchesFilter(item)) {
                 currentPage.add(item);
             }
 
@@ -111,6 +113,17 @@ public class InventoryMenu {
         }
 
         contents.add(currentPage);
+    }
+
+    private boolean matchesFilter(ItemStack item) {
+        if (filter == null) return true;
+        if (item.getItemMeta() != null && item.getItemMeta().hasDisplayName()) {
+            String displayName = PlainTextComponentSerializer.plainText()
+                    .serialize(item.getItemMeta().displayName()).toLowerCase();
+            if (displayName.contains(filter)) return true;
+        }
+        String materialName = item.getType().name().replace('_', ' ').toLowerCase();
+        return materialName.contains(filter);
     }
 
     public void renderInventory() {

--- a/src/main/java/de/kwantux/networks/terminals/inventory/InventoryMenuManager.java
+++ b/src/main/java/de/kwantux/networks/terminals/inventory/InventoryMenuManager.java
@@ -18,7 +18,11 @@ public class InventoryMenuManager {
     }
 
     static public void addInventoryMenu(Player player, Network network) {
-        list.add(new InventoryMenu(player, network));
+        list.add(new InventoryMenu(player, network, null));
+    }
+
+    static public void addInventoryMenu(Player player, Network network, String filter) {
+        list.add(new InventoryMenu(player, network, filter));
     }
 
     static public void removeInventoryMenu(Player player) {


### PR DESCRIPTION
Adds support for doing stuff like `/nt oak` to see all items with `oak` in the name.